### PR TITLE
Exporting macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/dotc
+++ b/bin/dotc
@@ -1,73 +1,73 @@
 #!/usr/bin/env node
-var spawn = require('child_process').spawn;
-var fs = require('fs');
-var load = require('../index.js');
-var search = require('../lib/search.js');
+var spawn = require('child_process').spawn
+var fs = require('fs')
+var load = require('../index.js')
+var search = require('../lib/search.js')
 
-var args = process.argv.slice(2);
-for (var i = 0; i < args.length; i++) {
+function main () {
+  var args = process.argv.slice(2)
+  for (var i = 0; i < args.length; i++) {
     if (/-[\w-]{2,}($|=)/.test(args[i])) {
-        args[i] = '-' + args[i];
+      args[i] = '-' + args[i]
     }
-}
+  }
 
-var argv = require('minimist')(args, {
+  var argv = require('minimist')(args, {
     'boolean': [ 'c', 'S', 'E', 'v', '###', 'pipe', 'help', 'h' ]
-});
-var files = argv._.filter(function (file) {
-    return !/\.a$/.test(file);
-});
+  })
+  var files = argv._.filter(function (file) {
+    return !/\.a$/.test(file)
+  })
 
-var afiles = argv._.filter(function (file) {
-    return /\.a$/.test(file);
-});
+  var afiles = argv._.filter(function (file) {
+    return /\.a$/.test(file)
+  })
 
-var command = process.argv[2];
-if (command === 'pre') {
-    files.shift();
-    return load(files).pipe(process.stdout);
-}
-else if (command === 'search') {
-    files.shift();
+  var command = process.argv[2]
+  if (command === 'pre') {
+    files.shift()
+    return load(files).pipe(process.stdout)
+  } else if (command === 'search') {
+    files.shift()
     var q = search(process.argv.slice(3))
-    q.pipe(process.stdout);
+    q.pipe(process.stdout)
     q.on('error', function (err) {
-        console.error(err + '');
-        process.exit(1);
-    });
-    return;
-}
-else if (command === 'help' || command === undefined || argv.h || argv.help) {
-    return fs.createReadStream(__dirname + '/usage.txt').pipe(process.stdout);
-}
-else if (command === 'build') {
-    files.shift();
-    process.argv.splice(2, 1);
-}
+      console.error(err + '')
+      process.exit(1)
+    })
+    return
+  } else if (command === 'help' || command === undefined || argv.h || argv.help) {
+    return fs.createReadStream(__dirname + '/usage.txt').pipe(process.stdout)
+  } else if (command === 'build') {
+    files.shift()
+    process.argv.splice(2, 1)
+  }
 
-var gargs = process.argv.slice(2);
+  var gargs = process.argv.slice(2)
 
-for (var i = 0; i < files.length; i++) {
-    var ix = gargs.indexOf(files[i]);
-    if (ix >= 0) gargs.splice(ix, 1);
-}
+  for (i = 0; i < files.length; i++) {
+    var ix = gargs.indexOf(files[i])
+    if (ix >= 0) gargs.splice(ix, 1)
+  }
 
-
-if(afiles.length > 0){
-   for(var i = 0; i < afiles.length; i++){
-      var iy = gargs.indexOf(afiles[i]);
-      if(iy >= 0) {
-         gargs.splice(iy, 1);
-         gargs.unshift(afiles[i])
+  if (afiles.length > 0) {
+    for (i = 0; i < afiles.length; i++) {
+      var iy = gargs.indexOf(afiles[i])
+      if (iy >= 0) {
+        gargs.splice(iy, 1)
+        gargs.unshift(afiles[i])
       }
-   }
-   gargs.unshift('-x', 'none')
+    }
+    gargs.unshift('-x', 'none')
+  }
+
+  gargs.unshift('-x', 'c++', '-D', 'DOTC', '-')
+
+  var cmd = process.env.CC || 'gcc'
+  var gcc = spawn(cmd, gargs)
+  gcc.stdout.pipe(process.stdout)
+  gcc.stderr.pipe(process.stderr)
+  load(files).pipe(gcc.stdin)
 }
 
-gargs.unshift('-x', 'c++', '-D', 'DOTC', '-');
-
-var cmd = process.env.CC || 'gcc';
-var gcc = spawn(cmd, gargs);
-gcc.stdout.pipe(process.stdout);
-gcc.stderr.pipe(process.stderr);
-load(files).pipe(gcc.stdin);
+main()

--- a/index.js
+++ b/index.js
@@ -1,27 +1,27 @@
-var fs = require('fs');
-var path = require('path');
-var through = require('through');
-var parse = require('./lib/parse.js');
+var fs = require('fs')
+var path = require('path')
+var through = require('through')
+var parse = require('./lib/parse.js')
 
 module.exports = function (files) {
-    if (!Array.isArray(files)) files = [ files ];
+  if (!Array.isArray(files)) files = [ files ]
 
-    var output = through();
-    files = files.slice();
+  var output = through()
+  files = files.slice()
 
-    (function next () {
-        if (files.length === 0) return output.queue(null);
-        var file = files.shift();
-        var rs = isStream(file) ? file : fs.createReadStream(file);
-        var p = rs.pipe(parse(path.dirname(file)));
+  ;(function next () {
+    if (files.length === 0) return output.queue(null)
+    var file = files.shift()
+    var rs = isStream(file) ? file : fs.createReadStream(file)
+    var p = rs.pipe(parse(path.dirname(file)))
 
-        p.on('data', function (buf) { output.queue(buf) });
-        p.on('end', next);
-    })();
+    p.on('data', function (buf) { output.queue(buf) })
+    p.on('end', next)
+  })()
 
-    return output;
-};
+  return output
+}
 
 function isStream (s) {
-    return s && typeof s.pipe === 'function';
+  return s && typeof s.pipe === 'function'
 }

--- a/index.js
+++ b/index.js
@@ -5,20 +5,20 @@ var parse = require('./lib/parse.js');
 
 module.exports = function (files) {
     if (!Array.isArray(files)) files = [ files ];
-    
+
     var output = through();
     files = files.slice();
-    
+
     (function next () {
         if (files.length === 0) return output.queue(null);
         var file = files.shift();
         var rs = isStream(file) ? file : fs.createReadStream(file);
         var p = rs.pipe(parse(path.dirname(file)));
-        
+
         p.on('data', function (buf) { output.queue(buf) });
         p.on('end', next);
     })();
-    
+
     return output;
 };
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,264 +1,258 @@
-var fs = require('fs');
-var path = require('path');
-var resolve = require('resolve');
+var fs = require('fs')
+var path = require('path')
+var resolve = require('resolve')
 
-var tokenize = require('c-tokenizer');
-var combine = require('stream-combiner');
-var Transform = require('stream').Transform;
+var tokenize = require('c-tokenizer')
+var combine = require('stream-combiner')
+var Transform = require('stream').Transform
 
 var sequences = {
-    require: [
-        { type: 'directive', content: '#require' },
-        { type: 'whitespace' },
-        { type: 'quote' },
-        { type: 'whitespace' },
-        { type: 'identifier', content: 'as' },
-        { type: 'whitespace' },
-        { type: 'identifier' },
-    ],
-    'export': [
-        { type: 'directive', content: '#export' },
-        { type: 'whitespace' },
-        { type: 'identifier' },
-        { type: 'whitespace' },
-        { type: 'identifier', content: 'as', optional: true },
-        { type: 'whitespace' },
-        { type: 'identifier' }
-    ],
-    'export=': [
-        { type: 'directive', content: '#export=' },
-        { type: 'whitespace' },
-        { type: 'identifier' }
-    ]
-};
+  require: [
+    { type: 'directive', content: '#require' },
+    { type: 'whitespace' },
+    { type: 'quote' },
+    { type: 'whitespace' },
+    { type: 'identifier', content: 'as' },
+    { type: 'whitespace' },
+    { type: 'identifier' }
+  ],
+  'export': [
+    { type: 'directive', content: '#export' },
+    { type: 'whitespace' },
+    { type: 'identifier' },
+    { type: 'whitespace' },
+    { type: 'identifier', content: 'as', optional: true },
+    { type: 'whitespace' },
+    { type: 'identifier' }
+  ],
+  'export=': [
+    { type: 'directive', content: '#export=' },
+    { type: 'whitespace' },
+    { type: 'identifier' }
+  ]
+}
 
 function makeState (name, cb) {
-    return {
-        states: sequences[name].concat(cb),
-        tokens: [],
-        index: 0
-    };
+  return {
+    states: sequences[name].concat(cb),
+    tokens: [],
+    index: 0
+  }
 }
 
 module.exports = function parse (dir, hashes, namespaces) {
-    if (!hashes) hashes = {};
-    var t = tokenize();
+  if (!hashes) hashes = {}
+  var t = tokenize()
 
-    var ns = '_' + Math.floor(Math.pow(16,8) * Math.random()).toString(16);
-    t.namespace = ns;
+  var ns = '_' + Math.floor(Math.pow(16, 8) * Math.random()).toString(16)
+  t.namespace = ns
 
-    var required = {};
-    var exported = {};
-    var states = [];
+  var required = {}
+  var exported = {}
+  var states = []
 
-    states.push(makeState('require', function (tokens, next) {
-        var p = tokens[2].content.replace(/^"|"$/g, '');
+  states.push(makeState('require', function (tokens, next) {
+    var p = tokens[2].content.replace(/^"|"$/g, '')
 
-        var opts = {
-            basedir: path.resolve(dir),
-            extensions: [ '.c', '.cc', '.cpp', '.c++', '.cxx' ],
-            packageFilter: function (pkg) {
-                pkg.main = pkg['main.c'];
-                return pkg;
-            }
-        };
-        resolve(p, opts, function (err, res) {
-            if (err) emit('error', err);
-            else resolvedPath(res, p, tokens, next)
-        });
-    }));
+    var opts = {
+      basedir: path.resolve(dir),
+      extensions: [ '.c', '.cc', '.cpp', '.c++', '.cxx' ],
+      packageFilter: function (pkg) {
+        pkg.main = pkg['main.c']
+        return pkg
+      }
+    }
+    resolve(p, opts, function (err, res) {
+      if (err) emit('error', err)
+      else resolvedPath(res, p, tokens, next)
+    })
+  }))
 
-    function resolvedPath (file, quote, tokens, next) {
-        if (hashes[file]) {
-            exported[hashes[file].namespace] = hashes[file].exported;
-            required[tokens[6].content] = hashes[file].namespace;
-            return next();
-        }
-
-        var rs = fs.createReadStream(file);
-        var sub = rs.pipe(parse(
-            path.dirname(file),
-            hashes,
-            (namespaces || []).concat(ns)
-        ));
-        hashes[file] = {
-            namespace: (namespaces || [])
-                .concat(ns, sub.namespace).slice(1).join('::')
-            ,
-            exported: {}
-        };
-
-        sub.on('export', function (nsp, ex, local) {
-            if (!exported[nsp]) {
-                exported[nsp] = hashes[file].exported = {};
-            }
-            if (exported[nsp]['=']) {
-                return emit('error', new Error(
-                    'multi export attempted with existing single export'
-                ));
-            }
-            exported[nsp][ex] = local;
-        });
-
-        sub.on('export=', function (nsp, ex) {
-            if (exported[nsp]) {
-                emit('error', 'single export attempted with '
-                    + 'existing multi exports'
-                );
-            }
-            else {
-                exported[nsp] = hashes[file].exported = { '=': ex };
-            }
-        });
-
-        emit('require', quote, tokens[6].content);
-        required[tokens[6].content] = sub.namespace;
-
-        tr.push('namespace ' + sub.namespace + ' {\n');
-
-        sub.on('data', function (buf) { tr.push(buf) });
-        sub.on('end', function () {
-            tr.push('\n};\n');
-            next();
-        });
+  function resolvedPath (file, quote, tokens, next) {
+    if (hashes[file]) {
+      exported[hashes[file].namespace] = hashes[file].exported
+      required[tokens[6].content] = hashes[file].namespace
+      return next()
     }
 
-    states.push(makeState('export', function (tokens, next) {
-        if (tokens.length === 4) {
-            emit('export', ns, tokens[2].content, tokens[2].content);
-        }
-        else {
-            emit('export', ns, tokens[6].content, tokens[2].content);
-        }
-        next();
-    }));
-
-    states.push(makeState('export=', function (tokens, next) {
-        emit('export=', ns, tokens[2].content);
-        next();
-    }));
-
-    var matching = null;
-    var waiting = null;
-
-    var tr = new Transform({ objectMode: true });
-    tr._transform = function (token, enc, next) {
-        var src = token.content;
-
-        if (waiting && waiting.name === 'exported') {
-            if (token.type === 'whitespace') {}
-            else if (token.type === 'operator' && token.content === '.') {
-                waiting.name = 'import id';
-            }
-            else {
-                return emit('error', new Error(
-                    'expected (.) operator, got: '
-                    + token.type + ' (' + token.content + ')'
-                ));
-            }
-            return next();
-        }
-        else if (waiting && waiting.name === 'import id') {
-            if (token.type === 'identifier') {
-                var name = waiting.exports[token.content];
-                if (!name) {
-                    return emit('error', new Error(
-                        'unresolved import: ' + token.content
-                    ));
-                }
-                this.push(waiting.exports[token.content]);
-                waiting = null;
-            }
-            else {
-                return emit('error', new Error(
-                    'unexpected token: ' + token.type
-                    + '. expected: identifier'
-                ));
-            }
-            return next();
-        }
-
-        if (matching) {
-            var m = matching.states[matching.index ++];
-            var matched = false;
-            if (m.type !== token.type) {
-                if (m.optional) {
-                    matching.index = matching.states.length - 1;
-                }
-                else return emit('error', new Error(
-                    'unexpected type: ' + m.type
-                    + '. expected: ' + token.type
-                ));
-            }
-            else if (m.content && m.content !== token.content) {
-                if (m.optional) {
-                    matching.index = matching.states.length - 1;
-                }
-                else return emit('error', new Error(
-                    'unexpected content: ' + JSON.stringify(token.content)
-                    + '. expected: ' + JSON.stringify(m.content)
-                ));
-            }
-            else {
-                matched = true;
-                matching.tokens.push(token);
-            }
-
-            var f = matching.states[matching.index];
-            if (typeof f === 'function') {
-                f(matching.tokens, next);
-                matching.index = 0;
-                matching.tokens = [];
-                matching = null;
-                if (!matched && !scanMatch(token)) this.push(src);
-                return;
-            }
-            else next();
-        }
-        else if (token.type === 'identifier' && required[token.content]) {
-            var nsp = required[token.content];
-            var ex = exported[nsp];
-
-            if (!ex) return emit('error', new Error(
-                'unknown export ' + token.content
-            ));
-            if (ex['=']) {
-                this.push(nsp + '::' + ex['=']);
-            }
-            else {
-                this.push(nsp + '::');
-                waiting = { name: 'exported', exports: exported[nsp] };
-            }
-            next();
-        }
-        else {
-            if (scanMatch(token)) return next();
-            this.push(src);
-            next();
-        }
-
-        function scanMatch (token) {
-            for (var i = 0; i < states.length; i++) {
-                var s = states[i].states[0];
-                if (token.type === s.type
-                && (!s.content || s.content === token.content)) {
-                    matching = states[i];
-                    matching.tokens.push(token);
-                    matching.index ++;
-                    return true;
-                }
-            }
-        }
-    };
-
-    t.on('error', function (err) { emit('error', err) });
-
-    var combined = combine(t, tr);
-    combined.namespace = ns;
-    combined.namestack = [ ns ].concat(namespaces || []);
-    return combined;
-
-    function emit () {
-        combined.emit.apply(combined, arguments);
+    var rs = fs.createReadStream(file)
+    var sub = rs.pipe(parse(
+      path.dirname(file),
+      hashes,
+      (namespaces || []).concat(ns)
+    ))
+    hashes[file] = {
+      namespace: (namespaces || [])
+        .concat(ns, sub.namespace).slice(1).join('::'),
+      exported: {}
     }
-};
+
+    sub.on('export', function (nsp, ex, local) {
+      if (!exported[nsp]) {
+        exported[nsp] = hashes[file].exported = {}
+      }
+      if (exported[nsp]['=']) {
+        return emit('error', new Error(
+          'multi export attempted with existing single export'
+        ))
+      }
+      exported[nsp][ex] = local
+    })
+
+    sub.on('export=', function (nsp, ex) {
+      if (exported[nsp]) {
+        emit('error', 'single export attempted with ' +
+          'existing multi exports'
+        )
+      } else {
+        exported[nsp] = hashes[file].exported = { '=': ex }
+      }
+    })
+
+    emit('require', quote, tokens[6].content)
+    required[tokens[6].content] = sub.namespace
+
+    tr.push('namespace ' + sub.namespace + ' {\n')
+
+    sub.on('data', function (buf) { tr.push(buf) })
+    sub.on('end', function () {
+      tr.push('\n};\n')
+      next()
+    })
+  }
+
+  states.push(makeState('export', function (tokens, next) {
+    if (tokens.length === 4) {
+      emit('export', ns, tokens[2].content, tokens[2].content)
+    } else {
+      emit('export', ns, tokens[6].content, tokens[2].content)
+    }
+    next()
+  }))
+
+  states.push(makeState('export=', function (tokens, next) {
+    emit('export=', ns, tokens[2].content)
+    next()
+  }))
+
+  var matching = null
+  var waiting = null
+
+  var tr = new Transform({ objectMode: true })
+  tr._transform = function (token, enc, next) {
+    var src = token.content
+
+    if (waiting && waiting.name === 'exported') {
+      if (token.type === 'whitespace') {
+      } else if (token.type === 'operator' && token.content === '.') {
+        waiting.name = 'import id'
+      } else {
+        return emit('error', new Error(
+          'expected (.) operator, got: ' +
+          token.type + ' (' + token.content + ')'
+        ))
+      }
+      return next()
+    } else if (waiting && waiting.name === 'import id') {
+      if (token.type === 'identifier') {
+        var name = waiting.exports[token.content]
+        if (!name) {
+          return emit('error', new Error(
+            'unresolved import: ' + token.content
+          ))
+        }
+        this.push(waiting.exports[token.content])
+        waiting = null
+      } else {
+        return emit('error', new Error(
+          'unexpected token: ' + token.type +
+          '. expected: identifier'
+        ))
+      }
+      return next()
+    }
+
+    if (matching) {
+      var m = matching.states[matching.index++]
+      var matched = false
+      if (m.type !== token.type) {
+        if (m.optional) {
+          matching.index = matching.states.length - 1
+        } else {
+          return emit('error', new Error(
+            'unexpected type: ' + m.type +
+            '. expected: ' + token.type
+          ))
+        }
+      } else if (m.content && m.content !== token.content) {
+        if (m.optional) {
+          matching.index = matching.states.length - 1
+        } else {
+          return emit('error', new Error(
+            'unexpected content: ' + JSON.stringify(token.content) +
+            '. expected: ' + JSON.stringify(m.content)
+          ))
+        }
+      } else {
+        matched = true
+        matching.tokens.push(token)
+      }
+
+      var f = matching.states[matching.index]
+      if (typeof f === 'function') {
+        f(matching.tokens, next)
+        matching.index = 0
+        matching.tokens = []
+        matching = null
+        if (!matched && !scanMatch(token)) this.push(src)
+        return
+      } else {
+        next()
+      }
+    } else if (token.type === 'identifier' && required[token.content]) {
+      var nsp = required[token.content]
+      var ex = exported[nsp]
+
+      if (!ex) {
+        return emit('error', new Error(
+          'unknown export ' + token.content
+        ))
+      }
+      if (ex['=']) {
+        this.push(nsp + '::' + ex['='])
+      } else {
+        this.push(nsp + '::')
+        waiting = { name: 'exported', exports: exported[nsp] }
+      }
+      next()
+    } else {
+      if (scanMatch(token)) return next()
+      this.push(src)
+      next()
+    }
+
+    function scanMatch (token) {
+      for (var i = 0; i < states.length; i++) {
+        var s = states[i].states[0]
+        if (token.type === s.type &&
+          (!s.content || s.content === token.content)) {
+          matching = states[i]
+          matching.tokens.push(token)
+          matching.index++
+          return true
+        }
+      }
+    }
+  }
+
+  t.on('error', function (err) { emit('error', err) })
+
+  var combined = combine(t, tr)
+  combined.namespace = ns
+  combined.namestack = [ ns ].concat(namespaces || [])
+  return combined
+
+  function emit () {
+    combined.emit.apply(combined, arguments)
+  }
+}

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -52,6 +52,7 @@ module.exports = function parse (dir, hashes, namespaces) {
 
   var ns = '_' + Math.floor(Math.pow(16, 8) * Math.random()).toString(16)
   t.namespace = ns
+  var namestack = (namespaces || []).concat(ns)
 
   var required = {}
   var exported = {}
@@ -77,7 +78,8 @@ module.exports = function parse (dir, hashes, namespaces) {
 
   function resolvedPath (file, quote, tokens, next) {
     if (hashes[file]) {
-      exported[hashes[file].namespaces.join('::')] = hashes[file].exported
+      var nsp = hashes[file].namespaces[hashes[file].namespaces.length - 1]
+      exported[nsp] = hashes[file].exported
       required[tokens[6].content] = hashes[file].namespaces
       return next()
     }
@@ -86,7 +88,7 @@ module.exports = function parse (dir, hashes, namespaces) {
     var sub = rs.pipe(parse(
       path.dirname(file),
       hashes,
-      (namespaces || []).concat(ns)
+      namestack
     ))
     hashes[file] = {
       namespaces: (namespaces || [])
@@ -140,7 +142,7 @@ module.exports = function parse (dir, hashes, namespaces) {
     })
 
     emit('require', quote, tokens[6].content)
-    required[tokens[6].content] = sub.namespace
+    required[tokens[6].content] = sub.namestack.reverse()
 
     tr.push('namespace ' + sub.namespace + ' {\n')
 
@@ -156,7 +158,7 @@ module.exports = function parse (dir, hashes, namespaces) {
       local: tokens[2].content,
       identifier: tokens[tokens.length === 4 ? 2 : 6].content,
       operator: '::',
-      namespaces: [ ns ]
+      namespaces: namestack.slice(1)
     })
     next()
   }))
@@ -166,7 +168,7 @@ module.exports = function parse (dir, hashes, namespaces) {
       local: tokens[2].content,
       identifier: tokens[2].content,
       operator: '::',
-      namespaces: [ ns ]
+      namespaces: namestack.slice(1)
     })
     next()
   }))
@@ -174,7 +176,7 @@ module.exports = function parse (dir, hashes, namespaces) {
   states.push(makeState('#define', function (tokens, next) {
     emit('#define', {
       identifier: tokens[2].content,
-      namespaces: [ ns ]
+      namespaces: namestack.slice(1)
     })
     next()
   }))
@@ -255,7 +257,8 @@ module.exports = function parse (dir, hashes, namespaces) {
         next()
       }
     } else if (token.type === 'identifier' && required[token.content]) {
-      var nsp = required[token.content]
+      var namespaces = required[token.content]
+      var nsp = namespaces[namespaces.length - 1]
       ex = exported[nsp]
 
       if (!ex) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -130,8 +130,16 @@ module.exports = function parse (dir, hashes, namespaces) {
       var nsp = macro.namespaces[macro.namespaces.length - 1]
       if (!macros[nsp]) macros[nsp] = {}
       macros[nsp][macro.identifier] = macro
-      tr.push('#define ')
-      tr.push(macro.namespaces.join('_') + '_' + macro.identifier)
+      var namespacedId = macro.namespaces.join('_') + '_' + macro.identifier
+
+      // undefine macro to hide warnings about redefinition
+      tr.push('#undef ' + macro.identifier + '\n')
+      // alias original macro id to namespaced macro id so we can use it in
+      // this source file
+      tr.push('#define ' + macro.identifier + ' ' + namespacedId + '\n')
+      // define macro as namespaced id (#define _namespace_macro)
+      tr.push('#define ' + namespacedId)
+
       if (!exported[nsp]) return
       for (var name in exported[nsp]) {
         var ex = exported[nsp][name]

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,7 +7,7 @@ var combine = require('stream-combiner')
 var Transform = require('stream').Transform
 
 var sequences = {
-  require: [
+  'require': [
     { type: 'directive', content: '#require' },
     { type: 'whitespace' },
     { type: 'quote' },
@@ -29,6 +29,12 @@ var sequences = {
     { type: 'directive', content: '#export=' },
     { type: 'whitespace' },
     { type: 'identifier' }
+  ],
+  '#define': [
+    { type: 'directive', content: '#define' },
+    { type: 'whitespace' },
+    { type: 'identifier' },
+    { type: '*', optional: true }
   ]
 }
 
@@ -49,6 +55,7 @@ module.exports = function parse (dir, hashes, namespaces) {
 
   var required = {}
   var exported = {}
+  var macros = {}
   var states = []
 
   states.push(makeState('require', function (tokens, next) {
@@ -70,8 +77,8 @@ module.exports = function parse (dir, hashes, namespaces) {
 
   function resolvedPath (file, quote, tokens, next) {
     if (hashes[file]) {
-      exported[hashes[file].namespace] = hashes[file].exported
-      required[tokens[6].content] = hashes[file].namespace
+      exported[hashes[file].namespaces.join('::')] = hashes[file].exported
+      required[tokens[6].content] = hashes[file].namespaces
       return next()
     }
 
@@ -82,12 +89,13 @@ module.exports = function parse (dir, hashes, namespaces) {
       (namespaces || []).concat(ns)
     ))
     hashes[file] = {
-      namespace: (namespaces || [])
-        .concat(ns, sub.namespace).slice(1).join('::'),
+      namespaces: (namespaces || [])
+        .concat(ns, sub.namespace).slice(1),
       exported: {}
     }
 
-    sub.on('export', function (nsp, ex, local) {
+    sub.on('export', function (ex) {
+      var nsp = ex.namespaces[ex.namespaces.length - 1]
       if (!exported[nsp]) {
         exported[nsp] = hashes[file].exported = {}
       }
@@ -96,16 +104,38 @@ module.exports = function parse (dir, hashes, namespaces) {
           'multi export attempted with existing single export'
         ))
       }
-      exported[nsp][ex] = local
+      if (macros[nsp] && macros[nsp][ex.local]) {
+        ex.operator = '_'
+      }
+      exported[nsp][ex.identifier] = ex
     })
 
-    sub.on('export=', function (nsp, ex) {
+    sub.on('export=', function (ex) {
+      var nsp = ex.namespaces[ex.namespaces.length - 1]
       if (exported[nsp]) {
         emit('error', 'single export attempted with ' +
           'existing multi exports'
         )
       } else {
+        if (macros[nsp] && macros[nsp][ex.local]) {
+          ex.operator = '_'
+        }
         exported[nsp] = hashes[file].exported = { '=': ex }
+      }
+    })
+
+    sub.on('#define', function (macro) {
+      var nsp = macro.namespaces[macro.namespaces.length - 1]
+      if (!macros[nsp]) macros[nsp] = {}
+      macros[nsp][macro.identifier] = macro
+      tr.push('#define ')
+      tr.push(macro.namespaces.join('_') + '_' + macro.identifier)
+      if (!exported[nsp]) return
+      for (var name in exported[nsp]) {
+        var ex = exported[nsp][name]
+        if (ex.local === macro.identifier) {
+          ex.operator = '_'
+        }
       }
     })
 
@@ -122,16 +152,30 @@ module.exports = function parse (dir, hashes, namespaces) {
   }
 
   states.push(makeState('export', function (tokens, next) {
-    if (tokens.length === 4) {
-      emit('export', ns, tokens[2].content, tokens[2].content)
-    } else {
-      emit('export', ns, tokens[6].content, tokens[2].content)
-    }
+    emit('export', {
+      local: tokens[2].content,
+      identifier: tokens[tokens.length === 4 ? 2 : 6].content,
+      operator: '::',
+      namespaces: [ ns ]
+    })
     next()
   }))
 
   states.push(makeState('export=', function (tokens, next) {
-    emit('export=', ns, tokens[2].content)
+    emit('export=', {
+      local: tokens[2].content,
+      identifier: tokens[2].content,
+      operator: '::',
+      namespaces: [ ns ]
+    })
+    next()
+  }))
+
+  states.push(makeState('#define', function (tokens, next) {
+    emit('#define', {
+      identifier: tokens[2].content,
+      namespaces: [ ns ]
+    })
     next()
   }))
 
@@ -141,6 +185,7 @@ module.exports = function parse (dir, hashes, namespaces) {
   var tr = new Transform({ objectMode: true })
   tr._transform = function (token, enc, next) {
     var src = token.content
+    var ex
 
     if (waiting && waiting.name === 'exported') {
       if (token.type === 'whitespace') {
@@ -155,13 +200,13 @@ module.exports = function parse (dir, hashes, namespaces) {
       return next()
     } else if (waiting && waiting.name === 'import id') {
       if (token.type === 'identifier') {
-        var name = waiting.exports[token.content]
-        if (!name) {
+        ex = waiting.exports[token.content]
+        if (!ex) {
           return emit('error', new Error(
             'unresolved import: ' + token.content
           ))
         }
-        this.push(waiting.exports[token.content])
+        this.push(ex.namespaces.join(ex.operator) + ex.operator + ex.local)
         waiting = null
       } else {
         return emit('error', new Error(
@@ -211,7 +256,7 @@ module.exports = function parse (dir, hashes, namespaces) {
       }
     } else if (token.type === 'identifier' && required[token.content]) {
       var nsp = required[token.content]
-      var ex = exported[nsp]
+      ex = exported[nsp]
 
       if (!ex) {
         return emit('error', new Error(
@@ -219,9 +264,9 @@ module.exports = function parse (dir, hashes, namespaces) {
         ))
       }
       if (ex['=']) {
-        this.push(nsp + '::' + ex['='])
+        this.push(ex['='].namespaces.join(ex['='].operator) +
+          ex['='].operator + ex['='].local)
       } else {
-        this.push(nsp + '::')
         waiting = { name: 'exported', exports: exported[nsp] }
       }
       next()

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -43,17 +43,17 @@ function makeState (name, cb) {
 module.exports = function parse (dir, hashes, namespaces) {
     if (!hashes) hashes = {};
     var t = tokenize();
-    
+
     var ns = '_' + Math.floor(Math.pow(16,8) * Math.random()).toString(16);
     t.namespace = ns;
-    
+
     var required = {};
     var exported = {};
     var states = [];
-    
+
     states.push(makeState('require', function (tokens, next) {
         var p = tokens[2].content.replace(/^"|"$/g, '');
-        
+
         var opts = {
             basedir: path.resolve(dir),
             extensions: [ '.c', '.cc', '.cpp', '.c++', '.cxx' ],
@@ -67,14 +67,14 @@ module.exports = function parse (dir, hashes, namespaces) {
             else resolvedPath(res, p, tokens, next)
         });
     }));
-    
+
     function resolvedPath (file, quote, tokens, next) {
         if (hashes[file]) {
             exported[hashes[file].namespace] = hashes[file].exported;
             required[tokens[6].content] = hashes[file].namespace;
             return next();
         }
-        
+
         var rs = fs.createReadStream(file);
         var sub = rs.pipe(parse(
             path.dirname(file),
@@ -87,7 +87,7 @@ module.exports = function parse (dir, hashes, namespaces) {
             ,
             exported: {}
         };
-        
+
         sub.on('export', function (nsp, ex, local) {
             if (!exported[nsp]) {
                 exported[nsp] = hashes[file].exported = {};
@@ -99,7 +99,7 @@ module.exports = function parse (dir, hashes, namespaces) {
             }
             exported[nsp][ex] = local;
         });
-        
+
         sub.on('export=', function (nsp, ex) {
             if (exported[nsp]) {
                 emit('error', 'single export attempted with '
@@ -110,19 +110,19 @@ module.exports = function parse (dir, hashes, namespaces) {
                 exported[nsp] = hashes[file].exported = { '=': ex };
             }
         });
-        
+
         emit('require', quote, tokens[6].content);
         required[tokens[6].content] = sub.namespace;
-        
+
         tr.push('namespace ' + sub.namespace + ' {\n');
-        
+
         sub.on('data', function (buf) { tr.push(buf) });
         sub.on('end', function () {
             tr.push('\n};\n');
             next();
         });
     }
-    
+
     states.push(makeState('export', function (tokens, next) {
         if (tokens.length === 4) {
             emit('export', ns, tokens[2].content, tokens[2].content);
@@ -132,19 +132,19 @@ module.exports = function parse (dir, hashes, namespaces) {
         }
         next();
     }));
-    
+
     states.push(makeState('export=', function (tokens, next) {
         emit('export=', ns, tokens[2].content);
         next();
     }));
-    
+
     var matching = null;
     var waiting = null;
-    
+
     var tr = new Transform({ objectMode: true });
     tr._transform = function (token, enc, next) {
         var src = token.content;
-                
+
         if (waiting && waiting.name === 'exported') {
             if (token.type === 'whitespace') {}
             else if (token.type === 'operator' && token.content === '.') {
@@ -177,7 +177,7 @@ module.exports = function parse (dir, hashes, namespaces) {
             }
             return next();
         }
-        
+
         if (matching) {
             var m = matching.states[matching.index ++];
             var matched = false;
@@ -186,7 +186,7 @@ module.exports = function parse (dir, hashes, namespaces) {
                     matching.index = matching.states.length - 1;
                 }
                 else return emit('error', new Error(
-                    'unexpected type: ' + m.type 
+                    'unexpected type: ' + m.type
                     + '. expected: ' + token.type
                 ));
             }
@@ -203,7 +203,7 @@ module.exports = function parse (dir, hashes, namespaces) {
                 matched = true;
                 matching.tokens.push(token);
             }
-            
+
             var f = matching.states[matching.index];
             if (typeof f === 'function') {
                 f(matching.tokens, next);
@@ -218,7 +218,7 @@ module.exports = function parse (dir, hashes, namespaces) {
         else if (token.type === 'identifier' && required[token.content]) {
             var nsp = required[token.content];
             var ex = exported[nsp];
-             
+
             if (!ex) return emit('error', new Error(
                 'unknown export ' + token.content
             ));
@@ -236,7 +236,7 @@ module.exports = function parse (dir, hashes, namespaces) {
             this.push(src);
             next();
         }
-        
+
         function scanMatch (token) {
             for (var i = 0; i < states.length; i++) {
                 var s = states[i].states[0];
@@ -250,14 +250,14 @@ module.exports = function parse (dir, hashes, namespaces) {
             }
         }
     };
-    
+
     t.on('error', function (err) { emit('error', err) });
-    
+
     var combined = combine(t, tr);
     combined.namespace = ns;
     combined.namestack = [ ns ].concat(namespaces || []);
     return combined;
-    
+
     function emit () {
         combined.emit.apply(combined, arguments);
     }

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,29 +1,29 @@
-var spawn = require('child_process').spawn;
-var split = require('split');
-var through = require('through');
+var spawn = require('child_process').spawn
+var split = require('split')
+var through = require('through')
 
 module.exports = function (terms, opts) {
-    if (!opts) opts = {};
-    var cols = opts.cols || process.stdout.columns || Infinity;
+  if (!opts) opts = {}
+  var cols = opts.cols || process.stdout.columns || Infinity
 
-    var args = [ 'search', '-s', '/\\.(c|cc|cpp|cxx|h)\\b/' ];
+  var args = [ 'search', '-s', '/\\.(c|cc|cpp|cxx|h)\\b/' ]
 
-    var ps = spawn('npm', args.concat(terms), { stdio: [ 0, 'pipe', 2 ] })
-    var lineNum = 0;
+  var ps = spawn('npm', args.concat(terms), { stdio: [ 0, 'pipe', 2 ] })
+  var lineNum = 0
 
-    var output = ps.stdout.pipe(split()).pipe(through(write));
+  var output = ps.stdout.pipe(split()).pipe(through(write))
 
-    ps.on('exit', function (code) {
-        if (code !== 0) {
-            output.emit('error', new Error('non-zero exit code running `npm`'));
-        }
-    });
-    return output;
-
-    function write (buf) {
-        var line = buf.toString('utf8');
-        if (lineNum++ === 0 || /^\S+\.(c|cc|cpp|cxx|h)\s/.test(line)) {
-            output.queue(line.substr(0, cols) + '\n');
-        }
+  ps.on('exit', function (code) {
+    if (code !== 0) {
+      output.emit('error', new Error('non-zero exit code running `npm`'))
     }
-};
+  })
+  return output
+
+  function write (buf) {
+    var line = buf.toString('utf8')
+    if (lineNum++ === 0 || /^\S+\.(c|cc|cpp|cxx|h)\s/.test(line)) {
+      output.queue(line.substr(0, cols) + '\n')
+    }
+  }
+}

--- a/lib/search.js
+++ b/lib/search.js
@@ -5,21 +5,21 @@ var through = require('through');
 module.exports = function (terms, opts) {
     if (!opts) opts = {};
     var cols = opts.cols || process.stdout.columns || Infinity;
-    
+
     var args = [ 'search', '-s', '/\\.(c|cc|cpp|cxx|h)\\b/' ];
-    
+
     var ps = spawn('npm', args.concat(terms), { stdio: [ 0, 'pipe', 2 ] })
     var lineNum = 0;
-    
+
     var output = ps.stdout.pipe(split()).pipe(through(write));
-    
+
     ps.on('exit', function (code) {
         if (code !== 0) {
             output.emit('error', new Error('non-zero exit code running `npm`'));
         }
     });
     return output;
-    
+
     function write (buf) {
         var line = buf.toString('utf8');
         if (lineNum++ === 0 || /^\S+\.(c|cc|cpp|cxx|h)\s/.test(line)) {

--- a/package.json
+++ b/package.json
@@ -15,13 +15,14 @@
     "split": "~0.2.10"
   },
   "devDependencies": {
-    "tap": "~0.4.4",
-    "uppercase.c": "~0.0.0",
     "concat-stream": "~1.0.1",
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.3.5",
+    "standard": "^6.0.8",
+    "tap": "~0.4.4",
+    "uppercase.c": "~0.0.0"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "standard && tap test/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/class.js
+++ b/test/class.js
@@ -13,7 +13,7 @@ test('class', function (t) {
     t.plan(3);
     var outfile = path.join(tmp, Math.random() + '.out');
     var ps = spawn(bin, [ __dirname + '/class/main.c', '-o', outfile ]);
-    
+
     ps.stderr.pipe(process.stderr);
     ps.stdout.pipe(process.stdout);
     ps.on('exit', function (code) {

--- a/test/class.js
+++ b/test/class.js
@@ -1,29 +1,29 @@
-var test = require('tap').test;
-var path = require('path');
-var spawn = require('child_process').spawn;
-var concat = require('concat-stream');
-var mkdirp = require('mkdirp');
+var test = require('tap').test
+var path = require('path')
+var spawn = require('child_process').spawn
+var concat = require('concat-stream')
+var mkdirp = require('mkdirp')
 
-var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random());
-mkdirp.sync(tmp);
+var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random())
+mkdirp.sync(tmp)
 
-var bin = __dirname + '/../bin/dotc';
+var bin = path.join(__dirname, '../bin/dotc')
 
 test('class', function (t) {
-    t.plan(3);
-    var outfile = path.join(tmp, Math.random() + '.out');
-    var ps = spawn(bin, [ __dirname + '/class/main.c', '-o', outfile ]);
+  t.plan(3)
+  var outfile = path.join(tmp, Math.random() + '.out')
+  var ps = spawn(bin, [ path.join(__dirname, 'class/main.c'), '-o', outfile ])
 
-    ps.stderr.pipe(process.stderr);
-    ps.stdout.pipe(process.stdout);
-    ps.on('exit', function (code) {
-        t.equal(code, 0);
-        var p = spawn(outfile, []);
-        p.stdout.pipe(concat(function (body) {
-            t.equal(body + '', '5\n');
-        }));
-        p.on('exit', function (code) {
-            t.equal(code, 0);
-        });
-    });
-});
+  ps.stderr.pipe(process.stderr)
+  ps.stdout.pipe(process.stdout)
+  ps.on('exit', function (code) {
+    t.equal(code, 0)
+    var p = spawn(outfile, [])
+    p.stdout.pipe(concat(function (body) {
+      t.equal(body + '', '5\n')
+    }))
+    p.on('exit', function (code) {
+      t.equal(code, 0)
+    })
+  })
+})

--- a/test/double.js
+++ b/test/double.js
@@ -13,7 +13,7 @@ test('double inclusion', function (t) {
     t.plan(4);
     var outfile = path.join(tmp, Math.random() + '.out');
     var ps = spawn(bin, [ __dirname + '/double/main.c', '-o', outfile ]);
-    
+
     ps.stderr.pipe(process.stderr);
     ps.stdout.pipe(process.stdout);
     ps.on('exit', function (code) {
@@ -26,7 +26,7 @@ test('double inclusion', function (t) {
             t.equal(code, 0);
         });
     });
-    
+
     var pre = spawn(bin, [ 'pre', __dirname + '/double/main.c' ]);
     pre.stdout.pipe(concat(function (body) {
         var m = body.toString('utf8').match(/\/\/ X FILE/g);

--- a/test/double.js
+++ b/test/double.js
@@ -23,7 +23,7 @@ test('double inclusion', function (t) {
       t.equal(body + '', '3663\n')
     }))
     p.on('exit', function (code) {
-      t.equal(code, 0)
+      t.equal(code, 15)
     })
   })
 

--- a/test/double.js
+++ b/test/double.js
@@ -1,35 +1,35 @@
-var test = require('tap').test;
-var path = require('path');
-var spawn = require('child_process').spawn;
-var concat = require('concat-stream');
-var mkdirp = require('mkdirp');
+var test = require('tap').test
+var path = require('path')
+var spawn = require('child_process').spawn
+var concat = require('concat-stream')
+var mkdirp = require('mkdirp')
 
-var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random());
-mkdirp.sync(tmp);
+var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random())
+mkdirp.sync(tmp)
 
-var bin = __dirname + '/../bin/dotc';
+var bin = path.join(__dirname, '../bin/dotc')
 
 test('double inclusion', function (t) {
-    t.plan(4);
-    var outfile = path.join(tmp, Math.random() + '.out');
-    var ps = spawn(bin, [ __dirname + '/double/main.c', '-o', outfile ]);
+  t.plan(4)
+  var outfile = path.join(tmp, Math.random() + '.out')
+  var ps = spawn(bin, [ path.join(__dirname, 'double/main.c'), '-o', outfile ])
 
-    ps.stderr.pipe(process.stderr);
-    ps.stdout.pipe(process.stdout);
-    ps.on('exit', function (code) {
-        t.equal(code, 0);
-        var p = spawn(outfile, [ '3', '5' ]);
-        p.stdout.pipe(concat(function (body) {
-            t.equal(body + '', '3663\n');
-        }));
-        p.on('exit', function (code) {
-            t.equal(code, 0);
-        });
-    });
+  ps.stderr.pipe(process.stderr)
+  ps.stdout.pipe(process.stdout)
+  ps.on('exit', function (code) {
+    t.equal(code, 0)
+    var p = spawn(outfile, [ '3', '5' ])
+    p.stdout.pipe(concat(function (body) {
+      t.equal(body + '', '3663\n')
+    }))
+    p.on('exit', function (code) {
+      t.equal(code, 0)
+    })
+  })
 
-    var pre = spawn(bin, [ 'pre', __dirname + '/double/main.c' ]);
-    pre.stdout.pipe(concat(function (body) {
-        var m = body.toString('utf8').match(/\/\/ X FILE/g);
-        t.equal(m.length, 1, 'include the X FILE only once');
-    }));
-});
+  var pre = spawn(bin, [ 'pre', path.join(__dirname, 'double/main.c') ])
+  pre.stdout.pipe(concat(function (body) {
+    var m = body.toString('utf8').match(/\/\/ X FILE/g)
+    t.equal(m.length, 1, 'include the X FILE only once')
+  }))
+})

--- a/test/double/macroA.c
+++ b/test/double/macroA.c
@@ -1,0 +1,5 @@
+#require "./macroB.c" as B
+
+#export= macro
+#define macro(a, b) \
+  B.b((a), (b))

--- a/test/double/macroB.c
+++ b/test/double/macroB.c
@@ -1,0 +1,2 @@
+#define macro(a, b) ((a) + (b))
+#export macro as b

--- a/test/double/main.c
+++ b/test/double/main.c
@@ -3,8 +3,9 @@
 
 #require "./bar.c" as b
 #require "./prefoo.c" as f
+#require "./macroA.c" as a
 
 int main(int argc, char **argv) {
     printf("%d\n", f(atoi(argv[1]) + b(atoi(argv[2]))));
-    return 0;
+    return a(5, 10);
 }

--- a/test/link.js
+++ b/test/link.js
@@ -1,43 +1,47 @@
-var test = require('tap').test;
-var path = require('path');
-var spawn = require('child_process').spawn;
-var concat = require('concat-stream');
-var mkdirp = require('mkdirp');
+var test = require('tap').test
+var path = require('path')
+var spawn = require('child_process').spawn
+var concat = require('concat-stream')
+var mkdirp = require('mkdirp')
 
-var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random());
-mkdirp.sync(tmp);
+var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random())
+mkdirp.sync(tmp)
 
-var bin = __dirname + '/../bin/dotc';
+var bin = path.join(__dirname, '/../bin/dotc')
 
 test('link .a file', function (t) {
-    t.plan(5);
-    //var outfile = path.join(, Math.random() + '.out');
-    var ps = spawn('gcc', [ '-c', __dirname + '/link/calc_mean.cc', '-I', __dirname + '/link', '-o', tmp + '/calc_mean.o'])
+  t.plan(5)
+  // var outfile = path.join(, Math.random() + '.out')
+  var ps = spawn('gcc', [ '-c', path.join(__dirname, 'link/calc_mean.cc'),
+    '-I', path.join(__dirname, '/link'), '-o', path.join(tmp, 'calc_mean.o') ])
 
-    ps.stderr.pipe(process.stderr);
-    ps.stdout.pipe(process.stdout);
-    ps.on('exit', function (code) {
-        t.equal(code, 0);
-        var p = spawn('ar', [ 'rcs', tmp + '/libmean.a', tmp + '/calc_mean.o']);
-        p.stderr.pipe(process.stderr);
-        p.stdout.pipe(process.stdout);
-        p.on('exit', function(code) {
-           t.equal(code, 0);
-            var q = spawn(bin, [__dirname + '/link/main.c', tmp + '/libmean.a', '-I', __dirname + '/link', '-o', tmp + '/a.out']);
-            q.stderr.pipe(process.stderr);
-            q.stdout.pipe(process.stdout);
-            q.on('exit', function(code) {
-                t.equal(code, 0);
-                var r = spawn(tmp + '/a.out', []);
-                r.stdout.pipe(concat(function (body) {
-                   t.equal(body + '', 'The mean of 5.20 and 7.90 is 6.55\n');
-                }));
-                r.on('exit', function (code) {
-                  t.equal(code, 0);
-                });
-            })
+  ps.stderr.pipe(process.stderr)
+  ps.stdout.pipe(process.stdout)
+  ps.on('exit', function (code) {
+    t.equal(code, 0)
+    var p = spawn('ar', [ 'rcs', path.join(tmp, 'libmean.a'), path.join(tmp, 'calc_mean.o') ])
+    p.stderr.pipe(process.stderr)
+    p.stdout.pipe(process.stdout)
+    p.on('exit', function (code) {
+      t.equal(code, 0)
+      var q = spawn(bin, [
+        path.join(__dirname, 'link/main.c'),
+        path.join(tmp, 'libmean.a'),
+        '-I', path.join(__dirname, 'link'),
+        '-o', path.join(tmp, 'a.out')
+      ])
+      q.stderr.pipe(process.stderr)
+      q.stdout.pipe(process.stdout)
+      q.on('exit', function (code) {
+        t.equal(code, 0)
+        var r = spawn(path.join(tmp, 'a.out'), [])
+        r.stdout.pipe(concat(function (body) {
+          t.equal(body + '', 'The mean of 5.20 and 7.90 is 6.55\n')
+        }))
+        r.on('exit', function (code) {
+          t.equal(code, 0)
         })
-
-
-    });
-});
+      })
+    })
+  })
+})

--- a/test/link.js
+++ b/test/link.js
@@ -13,7 +13,7 @@ test('link .a file', function (t) {
     t.plan(5);
     //var outfile = path.join(, Math.random() + '.out');
     var ps = spawn('gcc', [ '-c', __dirname + '/link/calc_mean.cc', '-I', __dirname + '/link', '-o', tmp + '/calc_mean.o'])
-    
+
     ps.stderr.pipe(process.stderr);
     ps.stdout.pipe(process.stdout);
     ps.on('exit', function (code) {
@@ -34,10 +34,10 @@ test('link .a file', function (t) {
                 }));
                 r.on('exit', function (code) {
                   t.equal(code, 0);
-                }); 
+                });
             })
         })
 
-        
+
     });
 });

--- a/test/module.js
+++ b/test/module.js
@@ -13,7 +13,7 @@ test('load a module installed with npm', function (t) {
     t.plan(3);
     var outfile = path.join(tmp, Math.random() + '.out');
     var ps = spawn(bin, [ __dirname + '/module/main.c', '-o', outfile ]);
-    
+
     ps.stderr.pipe(process.stderr);
     ps.stdout.pipe(process.stdout);
     ps.on('exit', function (code) {

--- a/test/module.js
+++ b/test/module.js
@@ -1,29 +1,29 @@
-var test = require('tap').test;
-var path = require('path');
-var spawn = require('child_process').spawn;
-var concat = require('concat-stream');
-var mkdirp = require('mkdirp');
+var test = require('tap').test
+var path = require('path')
+var spawn = require('child_process').spawn
+var concat = require('concat-stream')
+var mkdirp = require('mkdirp')
 
-var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random());
-mkdirp.sync(tmp);
+var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random())
+mkdirp.sync(tmp)
 
-var bin = __dirname + '/../bin/dotc';
+var bin = path.join(__dirname, '../bin/dotc')
 
 test('load a module installed with npm', function (t) {
-    t.plan(3);
-    var outfile = path.join(tmp, Math.random() + '.out');
-    var ps = spawn(bin, [ __dirname + '/module/main.c', '-o', outfile ]);
+  t.plan(3)
+  var outfile = path.join(tmp, Math.random() + '.out')
+  var ps = spawn(bin, [ path.join(__dirname, 'module/main.c'), '-o', outfile ])
 
-    ps.stderr.pipe(process.stderr);
-    ps.stdout.pipe(process.stdout);
-    ps.on('exit', function (code) {
-        t.equal(code, 0);
-        var p = spawn(outfile, [ 'hello', 'world' ]);
-        p.stdout.pipe(concat(function (body) {
-            t.equal(body.toString().trim(), 'HELLO WORLD');
-        }));
-        p.on('exit', function (code) {
-            t.equal(code, 0);
-        });
-    });
-});
+  ps.stderr.pipe(process.stderr)
+  ps.stdout.pipe(process.stdout)
+  ps.on('exit', function (code) {
+    t.equal(code, 0)
+    var p = spawn(outfile, [ 'hello', 'world' ])
+    p.stdout.pipe(concat(function (body) {
+      t.equal(body.toString().trim(), 'HELLO WORLD')
+    }))
+    p.on('exit', function (code) {
+      t.equal(code, 0)
+    })
+  })
+})

--- a/test/multi.js
+++ b/test/multi.js
@@ -1,29 +1,29 @@
-var test = require('tap').test;
-var path = require('path');
-var spawn = require('child_process').spawn;
-var concat = require('concat-stream');
-var mkdirp = require('mkdirp');
+var test = require('tap').test
+var path = require('path')
+var spawn = require('child_process').spawn
+var concat = require('concat-stream')
+var mkdirp = require('mkdirp')
 
-var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random());
-mkdirp.sync(tmp);
+var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random())
+mkdirp.sync(tmp)
 
-var bin = __dirname + '/../bin/dotc';
+var bin = path.join(__dirname, '../bin/dotc')
 
 test('multi export', function (t) {
-    t.plan(3);
-    var outfile = path.join(tmp, Math.random() + '.out');
-    var ps = spawn(bin, [ __dirname + '/multi/main.c', '-o', outfile ]);
+  t.plan(3)
+  var outfile = path.join(tmp, Math.random() + '.out')
+  var ps = spawn(bin, [ path.join(__dirname, 'multi/main.c'), '-o', outfile ])
 
-    ps.stderr.pipe(process.stderr);
-    ps.stdout.pipe(process.stdout);
-    ps.on('exit', function (code) {
-        t.equal(code, 0);
-        var p = spawn(outfile, [ '3', '4' ]);
-        p.stdout.pipe(concat(function (body) {
-            t.equal(body + '', '373\n');
-        }));
-        p.on('exit', function (code) {
-            t.equal(code, 0);
-        });
-    });
-});
+  ps.stderr.pipe(process.stderr)
+  ps.stdout.pipe(process.stdout)
+  ps.on('exit', function (code) {
+    t.equal(code, 0)
+    var p = spawn(outfile, [ '3', '4' ])
+    p.stdout.pipe(concat(function (body) {
+      t.equal(body + '', '373\n')
+    }))
+    p.on('exit', function (code) {
+      t.equal(code, 0)
+    })
+  })
+})

--- a/test/multi.js
+++ b/test/multi.js
@@ -23,7 +23,7 @@ test('multi export', function (t) {
       t.equal(body + '', '373\n')
     }))
     p.on('exit', function (code) {
-      t.equal(code, 0)
+      t.equal(code, 10)
     })
   })
 })

--- a/test/multi.js
+++ b/test/multi.js
@@ -13,7 +13,7 @@ test('multi export', function (t) {
     t.plan(3);
     var outfile = path.join(tmp, Math.random() + '.out');
     var ps = spawn(bin, [ __dirname + '/multi/main.c', '-o', outfile ]);
-    
+
     ps.stderr.pipe(process.stderr);
     ps.stdout.pipe(process.stdout);
     ps.on('exit', function (code) {

--- a/test/multi/foobar.c
+++ b/test/multi/foobar.c
@@ -3,7 +3,10 @@ int foo (int n) {
     return n * 111;
 }
 
+#export foo2
+#define foo2 10
+
 #export bazzy as bar
 int bazzy (int n) {
-    return n * 10;
+    return n * foo2;
 }

--- a/test/multi/main.c
+++ b/test/multi/main.c
@@ -7,5 +7,5 @@ int main(int argc, char **argv) {
     int f = FB.foo(atoi(argv[1]));
     int b = FB.bar(atoi(argv[2]));
     printf("%d\n", f + b);
-    return 0;
+    return FB.foo2;
 }

--- a/test/multi_grouped.js
+++ b/test/multi_grouped.js
@@ -23,7 +23,7 @@ test('multi export', function (t) {
       t.equal(body + '', '373\n')
     }))
     p.on('exit', function (code) {
-      t.equal(code, 0)
+      t.equal(code, 10)
     })
   })
 })

--- a/test/multi_grouped.js
+++ b/test/multi_grouped.js
@@ -1,29 +1,29 @@
-var test = require('tap').test;
-var path = require('path');
-var spawn = require('child_process').spawn;
-var concat = require('concat-stream');
-var mkdirp = require('mkdirp');
+var test = require('tap').test
+var path = require('path')
+var spawn = require('child_process').spawn
+var concat = require('concat-stream')
+var mkdirp = require('mkdirp')
 
-var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random());
-mkdirp.sync(tmp);
+var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random())
+mkdirp.sync(tmp)
 
-var bin = __dirname + '/../bin/dotc';
+var bin = path.join(__dirname, '../bin/dotc')
 
 test('multi export', function (t) {
-    t.plan(3);
-    var outfile = path.join(tmp, Math.random() + '.out');
-    var ps = spawn(bin, [ __dirname + '/multi_grouped/main.c', '-o', outfile ]);
+  t.plan(3)
+  var outfile = path.join(tmp, Math.random() + '.out')
+  var ps = spawn(bin, [ path.join(__dirname, 'multi_grouped/main.c'), '-o', outfile ])
 
-    ps.stderr.pipe(process.stderr);
-    ps.stdout.pipe(process.stdout);
-    ps.on('exit', function (code) {
-        t.equal(code, 0);
-        var p = spawn(outfile, [ '3', '4' ]);
-        p.stdout.pipe(concat(function (body) {
-            t.equal(body + '', '373\n');
-        }));
-        p.on('exit', function (code) {
-            t.equal(code, 0);
-        });
-    });
-});
+  ps.stderr.pipe(process.stderr)
+  ps.stdout.pipe(process.stdout)
+  ps.on('exit', function (code) {
+    t.equal(code, 0)
+    var p = spawn(outfile, [ '3', '4' ])
+    p.stdout.pipe(concat(function (body) {
+      t.equal(body + '', '373\n')
+    }))
+    p.on('exit', function (code) {
+      t.equal(code, 0)
+    })
+  })
+})

--- a/test/multi_grouped/foobar.c
+++ b/test/multi_grouped/foobar.c
@@ -1,10 +1,13 @@
 #export foo
 #export bazzy as bar
+#export foo2
 
 int foo (int n) {
     return n * 111;
 }
 
+#define foo2 10
+
 int bazzy (int n) {
-    return n * 10;
+    return n * foo2;
 }

--- a/test/multi_grouped/main.c
+++ b/test/multi_grouped/main.c
@@ -7,5 +7,5 @@ int main(int argc, char **argv) {
     int f = FB.foo(atoi(argv[1]));
     int b = FB.bar(atoi(argv[2]));
     printf("%d\n", f + b);
-    return 0;
+    return FB.foo2;
 }

--- a/test/single.js
+++ b/test/single.js
@@ -1,29 +1,29 @@
-var test = require('tap').test;
-var path = require('path');
-var spawn = require('child_process').spawn;
-var concat = require('concat-stream');
-var mkdirp = require('mkdirp');
+var test = require('tap').test
+var path = require('path')
+var spawn = require('child_process').spawn
+var concat = require('concat-stream')
+var mkdirp = require('mkdirp')
 
-var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random());
-mkdirp.sync(tmp);
+var tmp = path.join(require('os').tmpdir(), 'dotc-' + Math.random())
+mkdirp.sync(tmp)
 
-var bin = __dirname + '/../bin/dotc';
+var bin = path.join(__dirname, '../bin/dotc')
 
 test('single export', function (t) {
-    t.plan(3);
-    var outfile = path.join(tmp, Math.random() + '.out');
-    var ps = spawn(bin, [ __dirname + '/single/main.c', '-o', outfile ]);
+  t.plan(3)
+  var outfile = path.join(tmp, Math.random() + '.out')
+  var ps = spawn(bin, [ path.join(__dirname, 'single/main.c'), '-o', outfile ])
 
-    ps.stderr.pipe(process.stderr);
-    ps.stdout.pipe(process.stdout);
-    ps.on('exit', function (code) {
-        t.equal(code, 0);
-        var p = spawn(outfile, [ '3' ]);
-        p.stdout.pipe(concat(function (body) {
-            t.equal(body + '', '333\n');
-        }));
-        p.on('exit', function (code) {
-            t.equal(code, 0);
-        });
-    });
-});
+  ps.stderr.pipe(process.stderr)
+  ps.stdout.pipe(process.stdout)
+  ps.on('exit', function (code) {
+    t.equal(code, 0)
+    var p = spawn(outfile, [ '3' ])
+    p.stdout.pipe(concat(function (body) {
+      t.equal(body + '', '333\n')
+    }))
+    p.on('exit', function (code) {
+      t.equal(code, 0)
+    })
+  })
+})

--- a/test/single.js
+++ b/test/single.js
@@ -13,7 +13,7 @@ test('single export', function (t) {
     t.plan(3);
     var outfile = path.join(tmp, Math.random() + '.out');
     var ps = spawn(bin, [ __dirname + '/single/main.c', '-o', outfile ]);
-    
+
     ps.stderr.pipe(process.stderr);
     ps.stdout.pipe(process.stdout);
     ps.on('exit', function (code) {


### PR DESCRIPTION
I got macro exporting working, as described in #16.

Macro exports will now get transformed from
```c
#export foo
#define foo bar
```
to
```c
#undef foo
#define foo _namespace_foo
#define _namespace_foo bar
```
The `#undef` is to prevent warnings for macro redefinition (e.g. if another source file had a macro named `foo`, which already polluted the global macro namespace). The first `#define` is to alias the original macro name to the namespace-prefixed name, so that we can use `foo` in the source file where it was defined. And the last line actually defines the macro with the namespaced name for other files to require.

This PR also formats the source code to adhere to `standard`, and lints with `standard` when running tests. Let me know if this isn't desired.